### PR TITLE
Fix restic host to apply retention policy properly

### DIFF
--- a/manifests/infra-cluster/palworld/kustomization.yaml
+++ b/manifests/infra-cluster/palworld/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - ./statefulset.yaml
-  - ./backup
+  - ./snapshot
 
 namespace: palworld
 

--- a/manifests/infra-cluster/palworld/snapshot/cronjob.yaml
+++ b/manifests/infra-cluster/palworld/snapshot/cronjob.yaml
@@ -56,8 +56,6 @@ spec:
               env:
                 - name: RESTIC_PASSWORD
                   value: password
-                - name: RESTIC_HOST
-                  value: restic-backup
               volumeMounts:
                 - name: restic-script
                   mountPath: /scripts

--- a/manifests/infra-cluster/palworld/snapshot/cronjob.yaml
+++ b/manifests/infra-cluster/palworld/snapshot/cronjob.yaml
@@ -56,6 +56,8 @@ spec:
               env:
                 - name: RESTIC_PASSWORD
                   value: password
+                - name: RESTIC_HOST
+                  value: restic-backup
               volumeMounts:
                 - name: restic-script
                   mountPath: /scripts

--- a/manifests/infra-cluster/palworld/snapshot/script.sh
+++ b/manifests/infra-cluster/palworld/snapshot/script.sh
@@ -11,4 +11,4 @@ RESTIC_REPOSITORY="s3:${AWS_ENDPOINT_URL%/}/palworld"
 
 restic -r "${RESTIC_REPOSITORY?}" init || true
 restic -r "${RESTIC_REPOSITORY?}" --verbose backup /mnt/source/steamapps/common/PalServer/Pal/Saved/SaveGames
-restic -r "${RESTIC_REPOSITORY?}" forget --keep-last 20 --prune
+restic -r "${RESTIC_REPOSITORY?}" forget --keep-last 15 --prune

--- a/manifests/infra-cluster/palworld/snapshot/script.sh
+++ b/manifests/infra-cluster/palworld/snapshot/script.sh
@@ -11,4 +11,4 @@ RESTIC_REPOSITORY="s3:${AWS_ENDPOINT_URL%/}/palworld"
 
 restic -r "${RESTIC_REPOSITORY?}" init || true
 restic -r "${RESTIC_REPOSITORY?}" --verbose backup /mnt/source/steamapps/common/PalServer/Pal/Saved/SaveGames
-restic -r "${RESTIC_REPOSITORY?}" forget --keep-last 15 --prune
+restic -r "${RESTIC_REPOSITORY?}" forget --group-by=paths --keep-monthly 6 --keep-daily 7 --keep-last 36 --prune


### PR DESCRIPTION
forget --pruneがうまくいかないと思ったらhostnameが毎回違う（当然）からだった。

`--group-by=paths` でpathベースで削除対象を決定するように変更